### PR TITLE
feat: add publish script and public access config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "lerna run build",
     "pretty": "lerna run pretty --parallel",
-    "pretty:fix": "lerna run pretty:fix --parallel"
+    "pretty:fix": "lerna run pretty:fix --parallel",
+    "publish": "lerna run publish --parallel"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/hooks": "workspace:^",
@@ -34,5 +35,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/hooks": "workspace:^",
@@ -34,5 +35,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/dismissable-layer/package.json
+++ b/packages/dismissable-layer/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/hooks": "workspace:^",
@@ -34,5 +35,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/shared": "workspace:^",
@@ -32,5 +33,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/navigation-menu/package.json
+++ b/packages/navigation-menu/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/collection": "workspace:^",
@@ -38,5 +39,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/norn/package.json
+++ b/packages/norn/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/slot": "workspace:^",
@@ -32,5 +33,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/presence/package.json
+++ b/packages/presence/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/hooks": "workspace:^",
@@ -32,5 +33,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -31,5 +32,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/slot/package.json
+++ b/packages/slot/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/shared": "workspace:^",
@@ -32,5 +33,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
-    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)"
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o -print)",
+    "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
     "@norns-ui/norn": "workspace:^",
@@ -32,5 +33,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Updated `package.json` in root and all workspace packages to include a new `publish` script using `yarn npm publish --tolerate-republish` for easier package publishing.
- Added `publishConfig` with `access: public` to each package's `package.json` to ensure all packages are published with public access.
- Enabled the use of `lerna run publish --parallel` in the root `package.json` to publish all packages in parallel.
- Enhanced the workflow for maintaining and deploying packages across the monorepo.