### PR TITLE
fix(deps): update dependencies to use wildcard versions

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -22,9 +22,9 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/hooks": "workspace:^",
-    "@norns-ui/norn": "workspace:^",
-    "@norns-ui/shared": "workspace:^",
+    "@norns-ui/hooks": "*",
+    "@norns-ui/norn": "*",
+    "@norns-ui/shared": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -22,9 +22,9 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/hooks": "workspace:^",
-    "@norns-ui/shared": "workspace:^",
-    "@norns-ui/slot": "workspace:^",
+    "@norns-ui/hooks": "*",
+    "@norns-ui/shared": "*",
+    "@norns-ui/slot": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/dismissable-layer/package.json
+++ b/packages/dismissable-layer/package.json
@@ -22,9 +22,9 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/hooks": "workspace:^",
-    "@norns-ui/norn": "workspace:^",
-    "@norns-ui/shared": "workspace:^",
+    "@norns-ui/hooks": "*",
+    "@norns-ui/norn": "*",
+    "@norns-ui/shared": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -22,7 +22,7 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/shared": "workspace:^",
+    "@norns-ui/shared": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/navigation-menu/package.json
+++ b/packages/navigation-menu/package.json
@@ -22,13 +22,13 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/collection": "workspace:^",
-    "@norns-ui/dismissable-layer": "workspace:^",
-    "@norns-ui/hooks": "workspace:^",
-    "@norns-ui/norn": "workspace:^",
-    "@norns-ui/presence": "workspace:^",
-    "@norns-ui/shared": "workspace:^",
-    "@norns-ui/visually-hidden": "workspace:^",
+    "@norns-ui/collection": "*",
+    "@norns-ui/dismissable-layer": "*",
+    "@norns-ui/hooks": "*",
+    "@norns-ui/norn": "*",
+    "@norns-ui/presence": "*",
+    "@norns-ui/shared": "*",
+    "@norns-ui/visually-hidden": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/norn/package.json
+++ b/packages/norn/package.json
@@ -22,7 +22,7 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/slot": "workspace:^",
+    "@norns-ui/slot": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/presence/package.json
+++ b/packages/presence/package.json
@@ -22,7 +22,7 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/hooks": "workspace:^",
+    "@norns-ui/hooks": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/slot/package.json
+++ b/packages/slot/package.json
@@ -22,7 +22,7 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/shared": "workspace:^",
+    "@norns-ui/shared": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -22,7 +22,7 @@
     "publish": "yarn npm publish --tolerate-republish"
   },
   "dependencies": {
-    "@norns-ui/norn": "workspace:^",
+    "@norns-ui/norn": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
- Changed package dependencies from workspace references to wildcard versions ("*") in `package.json` files across all packages.
- Updated dependencies to use `"*"` instead of `"workspace:^"` for better flexibility in resolving package versions.
- Ensured consistency in how internal package dependencies are specified.