### PR TITLE
chore(build): update publish script to run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "lerna run build",
     "pretty": "lerna run pretty --parallel",
     "pretty:fix": "lerna run pretty:fix --parallel",
-    "publish": "lerna publish from-package"
+    "publish": "lerna run publish --parallel"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
- Changed the `publish` script in the root `package.json` from `lerna publish from-package` to `lerna run publish --parallel` for parallel execution of publish tasks.