### PR TITLE
chore(hooks): add publishConfig for public access

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,5 +34,8 @@
     "esbuild": "^0.23.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Added `publishConfig` section to `hooks` package with `access` set to `public` to ensure the package is published publicly.