### PR TITLE
feat(focus-guards): add FocusGuards component and build configuration

### DIFF
--- a/packages/focus-guards/esbuild.config.js
+++ b/packages/focus-guards/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/focus-guards/eslint.config.js
+++ b/packages/focus-guards/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/focus-guards/lib/FocusGuards.tsx
+++ b/packages/focus-guards/lib/FocusGuards.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {useEffect} from "react";
+
+/** Number of components which have requested interest to have focus guards */
+let count = 0;
+
+const createFocusGuard = () => {
+  const element = document.createElement("span");
+  element.setAttribute("data-norns-focus-guard", "");
+  element.tabIndex = 0;
+  element.style.outline = "none";
+  element.style.opacity = "0";
+  element.style.position = "fixed";
+  element.style.pointerEvents = "none";
+  return element;
+};
+
+/**
+ * Injects a pair of focus guards at the edges of the whole DOM tree
+ * to ensure `focusin` & `focusout` events can be caught consistently.
+ */
+const useFocusGuards = () => {
+  useEffect(() => {
+    const edgeGuards = document.querySelectorAll("[data-norns-focus-guard]");
+    document.body.insertAdjacentElement(
+      "afterbegin",
+      edgeGuards[0] ?? createFocusGuard(),
+    );
+    document.body.insertAdjacentElement(
+      "beforeend",
+      edgeGuards[1] ?? createFocusGuard(),
+    );
+    count++;
+
+    return () => {
+      if (count === 1) {
+        document
+          .querySelectorAll("[data-norns-focus-guard]")
+          .forEach((node) => node.remove());
+      }
+      count--;
+    };
+  }, []);
+};
+
+const FocusGuards = (props: any) => {
+  useFocusGuards();
+  return props.children;
+};
+
+export {FocusGuards, useFocusGuards};

--- a/packages/focus-guards/lib/index.ts
+++ b/packages/focus-guards/lib/index.ts
@@ -1,0 +1,1 @@
+export {FocusGuards, useFocusGuards} from "./FocusGuards";

--- a/packages/focus-guards/package.json
+++ b/packages/focus-guards/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@norns-ui/focus-guards",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/focus-guards/tsconfig.json
+++ b/packages/focus-guards/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}


### PR DESCRIPTION
- Implemented FocusGuards component with focus management across the DOM using useFocusGuards hook
- Configured esbuild for bundling into ESM and CJS formats
- Integrated tsup to generate TypeScript declaration files
- Added ESLint configuration using @norns-ui/eslint-config-norns
- Configured build, lint, prettier, and publish scripts in package.json
- Created TypeScript configuration with path aliasing