### PR TITLE
feat(portal): add Portal component and build configuration

### DIFF
--- a/packages/portal/esbuild.config.js
+++ b/packages/portal/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/portal/eslint.config.js
+++ b/packages/portal/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/portal/lib/Portal.tsx
+++ b/packages/portal/lib/Portal.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {useLayoutEffect} from "@norns-ui/hooks";
+import {Norn} from "@norns-ui/norn";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  useState,
+} from "react";
+import {createPortal} from "react-dom";
+
+const PORTAL_NAME = "Portal";
+
+type PortalElement = ElementRef<typeof Norn.div>;
+type NornDivProps = ComponentPropsWithoutRef<typeof Norn.div>;
+interface PortalProps extends NornDivProps {
+  /**
+   * An optional container where the portaled content should be appended.
+   */
+  container?: Element | DocumentFragment | null;
+}
+
+const Portal = forwardRef<PortalElement, PortalProps>(
+  ({container: containerProp, ...portalProps}, forwardedRef) => {
+    const [mounted, setMounted] = useState(false);
+    useLayoutEffect(() => setMounted(true), []);
+    const container = containerProp || (mounted && globalThis?.document?.body);
+    return container
+      ? createPortal(
+          <Norn.div {...portalProps} ref={forwardedRef} />,
+          container,
+        )
+      : null;
+  },
+);
+
+Portal.displayName = PORTAL_NAME;
+
+export {Portal};
+export type {PortalProps};

--- a/packages/portal/lib/index.ts
+++ b/packages/portal/lib/index.ts
@@ -1,0 +1,2 @@
+export type {PortalProps} from "./Portal";
+export {Portal} from "./Portal";

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@norns-ui/portal",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "@norns-ui/hooks": "workspace:^",
+    "@norns-ui/norn": "workspace:^",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/portal/tsconfig.json
+++ b/packages/portal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}


### PR DESCRIPTION
- Implemented Portal component using @norns-ui/norn with optional container support
- Configured esbuild for bundling into ESM and CJS formats
- Integrated tsup to generate TypeScript declaration files
- Added ESLint configuration using @norns-ui/eslint-config-norns
- Configured build, lint, prettier, and publish scripts in package.json
- Created TypeScript configuration with path aliasing