### PR TITLE
feat(dialog): implement Dialog components

### DIFF
--- a/packages/dialog/esbuild.config.js
+++ b/packages/dialog/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/dialog/eslint.config.js
+++ b/packages/dialog/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/dialog/lib/Dialog.tsx
+++ b/packages/dialog/lib/Dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {useControllableState, useId} from "@norns-ui/hooks";
+import {createContextScope, Scope} from "@norns-ui/shared";
+import {FC, ReactNode, RefObject, useCallback, useRef} from "react";
+
+import {DialogContentElement} from "./DialogContent";
+
+const DIALOG_NAME = "Dialog";
+
+type ScopedProps<P> = P & {scopeDialog?: Scope};
+const [createDialogContext, createDialogScope] =
+  createContextScope(DIALOG_NAME);
+
+type DialogContextValue = {
+  triggerRef: RefObject<HTMLButtonElement>;
+  contentRef: RefObject<DialogContentElement>;
+  contentId: string;
+  titleId: string;
+  descriptionId: string;
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  onOpenToggle(): void;
+  modal: boolean;
+};
+
+const [DialogProvider, useDialogContext] =
+  createDialogContext<DialogContextValue>(DIALOG_NAME);
+
+interface DialogProps {
+  children?: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?(open: boolean): void;
+  modal?: boolean;
+}
+
+const Dialog: FC<DialogProps> = ({
+  scopeDialog,
+  children,
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  modal = true,
+}: ScopedProps<DialogProps>) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<DialogContentElement>(null);
+  const [open = false, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+
+  return (
+    <DialogProvider
+      scope={scopeDialog}
+      triggerRef={triggerRef}
+      contentRef={contentRef}
+      contentId={useId()}
+      titleId={useId()}
+      descriptionId={useId()}
+      open={open}
+      onOpenChange={setOpen}
+      onOpenToggle={useCallback(
+        () => setOpen((prevOpen) => !prevOpen),
+        [setOpen],
+      )}
+      modal={modal}
+    >
+      {children}
+    </DialogProvider>
+  );
+};
+
+Dialog.displayName = DIALOG_NAME;
+
+export {
+  createDialogContext,
+  createDialogScope,
+  Dialog,
+  DialogProvider,
+  useDialogContext,
+};
+export type {DialogProps, ScopedProps};

--- a/packages/dialog/lib/DialogClose.tsx
+++ b/packages/dialog/lib/DialogClose.tsx
@@ -1,0 +1,33 @@
+import {Norn} from "@norns-ui/norn";
+import {composeEventHandlers} from "@norns-ui/shared";
+import {ElementRef, forwardRef} from "react";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+import {NornButtonProps} from "./DialogTrigger";
+
+const CLOSE_NAME = "DialogClose";
+
+type DialogCloseElement = ElementRef<typeof Norn.button>;
+interface DialogCloseProps extends NornButtonProps {}
+
+const DialogClose = forwardRef<DialogCloseElement, DialogCloseProps>(
+  (props: ScopedProps<DialogCloseProps>, forwardedRef) => {
+    const {scopeDialog, ...closeProps} = props;
+    const context = useDialogContext(CLOSE_NAME, scopeDialog);
+    return (
+      <Norn.button
+        type="button"
+        {...closeProps}
+        ref={forwardedRef}
+        onClick={composeEventHandlers(props.onClick, () =>
+          context.onOpenChange(false),
+        )}
+      />
+    );
+  },
+);
+
+DialogClose.displayName = CLOSE_NAME;
+
+export {DialogClose};
+export type {DialogCloseProps};

--- a/packages/dialog/lib/DialogContent.tsx
+++ b/packages/dialog/lib/DialogContent.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import {DismissableLayer} from "@norns-ui/dismissable-layer";
+import {useFocusGuards} from "@norns-ui/focus-guards";
+import {FocusScope} from "@norns-ui/focus-scope";
+import {useComposedRefs} from "@norns-ui/hooks";
+import {Presence} from "@norns-ui/presence";
+import {composeEventHandlers, getOpenState} from "@norns-ui/shared";
+import {hideOthers} from "aria-hidden";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  useEffect,
+  useRef,
+} from "react";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+import {usePortalContext} from "./DialogPortal";
+import {DescriptionWarning, TitleWarning} from "./Warning";
+
+const CONTENT_NAME = "DialogContent";
+
+type DialogContentImplElement = ElementRef<typeof DismissableLayer>;
+type DismissableLayerProps = ComponentPropsWithoutRef<typeof DismissableLayer>;
+type FocusScopeProps = ComponentPropsWithoutRef<typeof FocusScope>;
+interface DialogContentImplProps
+  extends Omit<DismissableLayerProps, "onDismiss"> {
+  /**
+   * When `true`, focus cannot escape the `Content` via keyboard,
+   * pointer, or a programmatic focus.
+   * @defaultValue false
+   */
+  trapFocus?: FocusScopeProps["trapped"];
+
+  /**
+   * Event handler called when auto-focusing on open.
+   * Can be prevented.
+   */
+  onOpenAutoFocus?: FocusScopeProps["onMountAutoFocus"];
+
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  onCloseAutoFocus?: FocusScopeProps["onUnmountAutoFocus"];
+}
+
+const DialogContentImpl = forwardRef<
+  DialogContentImplElement,
+  DialogContentImplProps
+>(
+  (
+    {
+      scopeDialog,
+      trapFocus,
+      onOpenAutoFocus,
+      onCloseAutoFocus,
+      ...contentProps
+    }: ScopedProps<DialogContentImplProps>,
+    forwardedRef,
+  ) => {
+    const context = useDialogContext(CONTENT_NAME, scopeDialog);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+    // Make sure the whole tree has focus guards as our `Dialog` will be
+    // the last element in the DOM (because of the `Portal`)
+    useFocusGuards();
+
+    return (
+      <>
+        <FocusScope
+          asChild
+          loop
+          trapped={trapFocus}
+          onMountAutoFocus={onOpenAutoFocus}
+          onUnmountAutoFocus={onCloseAutoFocus}
+        >
+          <DismissableLayer
+            role="dialog"
+            id={context.contentId}
+            aria-describedby={context.descriptionId}
+            aria-labelledby={context.titleId}
+            data-state={getOpenState(context.open)}
+            {...contentProps}
+            ref={composedRefs}
+            onDismiss={() => context.onOpenChange(false)}
+          />
+        </FocusScope>
+        {process.env.NODE_ENV !== "production" && (
+          <>
+            <TitleWarning titleId={context.titleId} />
+            <DescriptionWarning
+              contentRef={contentRef}
+              descriptionId={context.descriptionId}
+            />
+          </>
+        )}
+      </>
+    );
+  },
+);
+
+const DialogContentNonModal = forwardRef<
+  DialogContentTypeElement,
+  DialogContentTypeProps
+>((props: ScopedProps<DialogContentTypeProps>, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME, props.scopeDialog);
+  const hasInteractedOutsideRef = useRef(false);
+  const hasPointerDownOutsideRef = useRef(false);
+
+  return (
+    <DialogContentImpl
+      {...props}
+      ref={forwardedRef}
+      trapFocus={false}
+      disableOutsidePointerEvents={false}
+      onCloseAutoFocus={(event) => {
+        props.onCloseAutoFocus?.(event);
+
+        if (!event.defaultPrevented) {
+          if (!hasInteractedOutsideRef.current) {
+            context.triggerRef.current?.focus();
+          }
+          // Always prevent auto focus because we either focus manually or want user agent focus
+          event.preventDefault();
+        }
+
+        hasInteractedOutsideRef.current = false;
+        hasPointerDownOutsideRef.current = false;
+      }}
+      onInteractOutside={(event) => {
+        props.onInteractOutside?.(event);
+
+        if (!event.defaultPrevented) {
+          hasInteractedOutsideRef.current = true;
+          if (event.detail.originalEvent.type === "pointerdown") {
+            hasPointerDownOutsideRef.current = true;
+          }
+        }
+
+        // Prevent dismissing when clicking the trigger.
+        // As the trigger is already setup to close, without doing so would
+        // cause it to close and immediately open.
+        const target = event.target as HTMLElement;
+        const targetIsTrigger = context.triggerRef.current?.contains(target);
+        if (targetIsTrigger) {
+          event.preventDefault();
+        }
+
+        // On Safari if the trigger is inside a container with tabIndex={0}, when clicked
+        // we will get the pointer down outside event on the trigger, but then a subsequent
+        // focus outside event on the container, we ignore any focus outside event when we've
+        // already had a pointer down outside event.
+        if (
+          event.detail.originalEvent.type === "focusin" &&
+          hasPointerDownOutsideRef.current
+        ) {
+          event.preventDefault();
+        }
+      }}
+    />
+  );
+});
+
+type DialogContentTypeElement = DialogContentImplElement;
+interface DialogContentTypeProps
+  extends Omit<
+    DialogContentImplProps,
+    "trapFocus" | "disableOutsidePointerEvents"
+  > {}
+
+const DialogContentModal = forwardRef<
+  DialogContentTypeElement,
+  DialogContentTypeProps
+>((props: ScopedProps<DialogContentTypeProps>, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME, props.scopeDialog);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(
+    forwardedRef,
+    context.contentRef,
+    contentRef,
+  );
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  useEffect(() => {
+    const content = contentRef.current;
+    if (content) {
+      return hideOthers(content);
+    }
+  }, []);
+
+  return (
+    <DialogContentImpl
+      {...props}
+      ref={composedRefs}
+      // we make sure focus isn't trapped once `DialogContent` has been closed
+      // (closed !== unmounted when animating out)
+      trapFocus={context.open}
+      disableOutsidePointerEvents
+      onCloseAutoFocus={composeEventHandlers(
+        props.onCloseAutoFocus,
+        (event) => {
+          event.preventDefault();
+          context.triggerRef.current?.focus();
+        },
+      )}
+      onPointerDownOutside={composeEventHandlers(
+        props.onPointerDownOutside,
+        (event) => {
+          const originalEvent = event.detail.originalEvent;
+          const ctrlLeftClick =
+            originalEvent.button === 0 && originalEvent.ctrlKey === true;
+          const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+
+          // If the event is a right-click, we shouldn't close because
+          // it is effectively as if we right-clicked the `Overlay`.
+          if (isRightClick) {
+            event.preventDefault();
+          }
+        },
+      )}
+      // When focus is trapped, a `focusout` event may still happen.
+      // We make sure we don't trigger our `onDismiss` in such case.
+      onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+        event.preventDefault(),
+      )}
+    />
+  );
+});
+
+type DialogContentElement = DialogContentTypeElement;
+interface DialogContentProps extends DialogContentTypeProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogContent = forwardRef<DialogContentElement, DialogContentProps>(
+  (props: ScopedProps<DialogContentProps>, forwardedRef) => {
+    const portalContext = usePortalContext(CONTENT_NAME, props.scopeDialog);
+    const {forceMount = portalContext.forceMount, ...contentProps} = props;
+    const context = useDialogContext(CONTENT_NAME, props.scopeDialog);
+    return (
+      <Presence present={forceMount || context.open}>
+        {context.modal ? (
+          <DialogContentModal {...contentProps} ref={forwardedRef} />
+        ) : (
+          <DialogContentNonModal {...contentProps} ref={forwardedRef} />
+        )}
+      </Presence>
+    );
+  },
+);
+
+DialogContent.displayName = CONTENT_NAME;
+
+export {CONTENT_NAME, DialogContent};
+export type {DialogContentElement, DialogContentProps};

--- a/packages/dialog/lib/DialogDescription.tsx
+++ b/packages/dialog/lib/DialogDescription.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react/prop-types */
+"use client";
+
+import {Norn} from "@norns-ui/norn";
+import React from "react";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+
+const DESCRIPTION_NAME = "DialogDescription";
+
+type DialogDescriptionElement = React.ElementRef<typeof Norn.p>;
+type NornParagraphProps = React.ComponentPropsWithoutRef<typeof Norn.p>;
+interface DialogDescriptionProps extends NornParagraphProps {}
+
+const DialogDescription = React.forwardRef<
+  DialogDescriptionElement,
+  DialogDescriptionProps
+>(
+  (
+    {scopeDialog, ...descriptionProps}: ScopedProps<DialogDescriptionProps>,
+    forwardedRef,
+  ) => {
+    const context = useDialogContext(DESCRIPTION_NAME, scopeDialog);
+    return (
+      <Norn.p
+        id={context.descriptionId}
+        {...descriptionProps}
+        ref={forwardedRef}
+      />
+    );
+  },
+);
+
+DialogDescription.displayName = DESCRIPTION_NAME;
+
+export {DialogDescription};
+export type {DialogDescriptionProps};

--- a/packages/dialog/lib/DialogOverlay.tsx
+++ b/packages/dialog/lib/DialogOverlay.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {Norn} from "@norns-ui/norn";
+import {Presence} from "@norns-ui/presence";
+import {getOpenState} from "@norns-ui/shared";
+import {Slot} from "@norns-ui/slot";
+import {ComponentPropsWithoutRef, ElementRef, forwardRef} from "react";
+import {RemoveScroll} from "react-remove-scroll";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+import {usePortalContext} from "./DialogPortal";
+
+const OVERLAY_NAME = "DialogOverlay";
+
+type DialogOverlayImplElement = ElementRef<typeof Norn.div>;
+type NornDivProps = ComponentPropsWithoutRef<typeof Norn.div>;
+interface DialogOverlayImplProps extends NornDivProps {}
+
+const DialogOverlayImpl = forwardRef<
+  DialogOverlayImplElement,
+  DialogOverlayImplProps
+>(
+  (
+    {scopeDialog, ...overlayProps}: ScopedProps<DialogOverlayImplProps>,
+    forwardedRef,
+  ) => {
+    const context = useDialogContext(OVERLAY_NAME, scopeDialog);
+    return (
+      // Make sure `Content` is scrollable even when it doesn't live inside `RemoveScroll`
+      // ie. when `Overlay` and `Content` are siblings
+      <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
+        <Norn.div
+          data-state={getOpenState(context.open)}
+          {...overlayProps}
+          ref={forwardedRef}
+          // We re-enable pointer-events prevented by `Dialog.Content` to allow scrolling the overlay.
+          style={{pointerEvents: "auto", ...overlayProps.style}}
+        />
+      </RemoveScroll>
+    );
+  },
+);
+
+type DialogOverlayElement = DialogOverlayImplElement;
+interface DialogOverlayProps extends DialogOverlayImplProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogOverlay = forwardRef<DialogOverlayElement, DialogOverlayProps>(
+  (props: ScopedProps<DialogOverlayProps>, forwardedRef) => {
+    const portalContext = usePortalContext(OVERLAY_NAME, props.scopeDialog);
+    const {forceMount = portalContext.forceMount, ...overlayProps} = props;
+    const context = useDialogContext(OVERLAY_NAME, props.scopeDialog);
+    return context.modal ? (
+      <Presence present={forceMount || context.open}>
+        <DialogOverlayImpl {...overlayProps} ref={forwardedRef} />
+      </Presence>
+    ) : null;
+  },
+);
+
+DialogOverlay.displayName = OVERLAY_NAME;
+
+export {DialogOverlay};
+export type {DialogOverlayProps};

--- a/packages/dialog/lib/DialogPortal.tsx
+++ b/packages/dialog/lib/DialogPortal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {Portal} from "@norns-ui/portal";
+import {Presence} from "@norns-ui/presence";
+import {Children, ComponentPropsWithoutRef, FC, ReactNode} from "react";
+
+import {createDialogContext, ScopedProps, useDialogContext} from "./Dialog";
+
+const PORTAL_NAME = "DialogPortal";
+
+type PortalContextValue = {forceMount?: true};
+const [PortalProvider, usePortalContext] =
+  createDialogContext<PortalContextValue>(PORTAL_NAME, {
+    forceMount: undefined,
+  });
+
+type PortalProps = ComponentPropsWithoutRef<typeof Portal>;
+interface DialogPortalProps {
+  children?: ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps["container"];
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
+
+const DialogPortal: FC<DialogPortalProps> = ({
+  scopeDialog,
+  forceMount,
+  children,
+  container,
+}: ScopedProps<DialogPortalProps>) => {
+  const context = useDialogContext(PORTAL_NAME, scopeDialog);
+  return (
+    <PortalProvider scope={scopeDialog} forceMount={forceMount}>
+      {Children.map(children, (child) => (
+        <Presence present={forceMount || context.open}>
+          <Portal asChild container={container}>
+            {child}
+          </Portal>
+        </Presence>
+      ))}
+    </PortalProvider>
+  );
+};
+
+DialogPortal.displayName = PORTAL_NAME;
+
+export {DialogPortal, usePortalContext};
+export type {DialogPortalProps};

--- a/packages/dialog/lib/DialogTitle.tsx
+++ b/packages/dialog/lib/DialogTitle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import {Norn} from "@norns-ui/norn";
+import {ComponentPropsWithoutRef, ElementRef, forwardRef} from "react";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+
+const TITLE_NAME = "DialogTitle";
+
+type DialogTitleElement = ElementRef<typeof Norn.h2>;
+type NornHeading2Props = ComponentPropsWithoutRef<typeof Norn.h2>;
+interface DialogTitleProps extends NornHeading2Props {}
+
+const DialogTitle = forwardRef<DialogTitleElement, DialogTitleProps>(
+  (
+    {scopeDialog, ...titleProps}: ScopedProps<DialogTitleProps>,
+    forwardedRef,
+  ) => {
+    const context = useDialogContext(TITLE_NAME, scopeDialog);
+    return <Norn.h2 id={context.titleId} {...titleProps} ref={forwardedRef} />;
+  },
+);
+
+DialogTitle.displayName = TITLE_NAME;
+
+export {DialogTitle, TITLE_NAME};
+export type {DialogTitleProps};

--- a/packages/dialog/lib/DialogTrigger.tsx
+++ b/packages/dialog/lib/DialogTrigger.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import {useComposedRefs} from "@norns-ui/hooks";
+import {Norn} from "@norns-ui/norn";
+import {composeEventHandlers, getOpenState} from "@norns-ui/shared";
+import {ComponentPropsWithoutRef, ElementRef, forwardRef} from "react";
+
+import {ScopedProps, useDialogContext} from "./Dialog";
+
+const TRIGGER_NAME = "DialogTrigger";
+
+type DialogTriggerElement = ElementRef<typeof Norn.button>;
+type NornButtonProps = ComponentPropsWithoutRef<typeof Norn.button>;
+interface DialogTriggerProps extends NornButtonProps {}
+
+const DialogTrigger = forwardRef<DialogTriggerElement, DialogTriggerProps>(
+  (props: ScopedProps<DialogTriggerProps>, forwardedRef) => {
+    const {scopeDialog, ...triggerProps} = props;
+    const context = useDialogContext(TRIGGER_NAME, scopeDialog);
+    const composedTriggerRef = useComposedRefs(
+      forwardedRef,
+      context.triggerRef,
+    );
+    return (
+      <Norn.button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={context.open}
+        aria-controls={context.contentId}
+        data-state={getOpenState(context.open)}
+        {...triggerProps}
+        ref={composedTriggerRef}
+        onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+      />
+    );
+  },
+);
+
+DialogTrigger.displayName = TRIGGER_NAME;
+
+export {DialogTrigger};
+export type {DialogTriggerProps, NornButtonProps};

--- a/packages/dialog/lib/Warning.tsx
+++ b/packages/dialog/lib/Warning.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+"use client";
+
+import {createContext} from "@norns-ui/shared";
+import {FC, RefObject, useEffect} from "react";
+
+import {CONTENT_NAME, DialogContentElement} from "./DialogContent";
+import {TITLE_NAME} from "./DialogTitle";
+
+const TITLE_WARNING_NAME = "DialogTitleWarning";
+
+const [WarningProvider, useWarningContext] = createContext(TITLE_WARNING_NAME, {
+  contentName: CONTENT_NAME,
+  titleName: TITLE_NAME,
+});
+
+type TitleWarningProps = {titleId?: string};
+
+const TitleWarning: FC<TitleWarningProps> = ({titleId}) => {
+  const titleWarningContext = useWarningContext(TITLE_WARNING_NAME) as {
+    contentName: string;
+    titleName: string;
+  };
+
+  const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
+
+If you want to hide the \`${titleWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component`;
+
+  useEffect(() => {
+    if (titleId) {
+      const hasTitle = document.getElementById(titleId);
+      if (!hasTitle) {
+        console.error(MESSAGE);
+      }
+    }
+  }, [MESSAGE, titleId]);
+
+  return null;
+};
+
+const DESCRIPTION_WARNING_NAME = "DialogDescriptionWarning";
+
+type DescriptionWarningProps = {
+  contentRef: RefObject<DialogContentElement>;
+  descriptionId?: string;
+};
+
+const DescriptionWarning: FC<DescriptionWarningProps> = ({
+  contentRef,
+  descriptionId,
+}) => {
+  const descriptionWarningContext = useWarningContext(
+    DESCRIPTION_WARNING_NAME,
+  ) as {
+    contentName: string;
+    titleName: string;
+  };
+  const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext?.contentName}}.`;
+
+  useEffect(() => {
+    const describedById = contentRef.current?.getAttribute("aria-describedby");
+    // if we have an id and the user hasn't set aria-describedby={undefined}
+    if (descriptionId && describedById) {
+      const hasDescription = document.getElementById(descriptionId);
+      if (!hasDescription) {
+        console.warn(MESSAGE);
+      }
+    }
+  }, [MESSAGE, contentRef, descriptionId]);
+
+  return null;
+};
+
+export {DescriptionWarning, TitleWarning, WarningProvider};
+export type {DescriptionWarningProps, TitleWarningProps};

--- a/packages/dialog/lib/index.ts
+++ b/packages/dialog/lib/index.ts
@@ -1,0 +1,17 @@
+export type {DialogProps} from "./Dialog";
+export {createDialogScope, Dialog} from "./Dialog";
+export type {DialogCloseProps} from "./DialogClose";
+export {DialogClose} from "./DialogClose";
+export type {DialogContentProps} from "./DialogContent";
+export {DialogContent} from "./DialogContent";
+export type {DialogDescriptionProps} from "./DialogDescription";
+export {DialogDescription} from "./DialogDescription";
+export type {DialogOverlayProps} from "./DialogOverlay";
+export {DialogOverlay} from "./DialogOverlay";
+export type {DialogPortalProps} from "./DialogPortal";
+export {DialogPortal} from "./DialogPortal";
+export type {DialogTitleProps} from "./DialogTitle";
+export {DialogTitle} from "./DialogTitle";
+export type {DialogTriggerProps} from "./DialogTrigger";
+export {DialogTrigger} from "./DialogTrigger";
+export {WarningProvider} from "./Warning";

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@norns-ui/dialog",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "@norns-ui/dismissable-layer": "workspace:^",
+    "@norns-ui/focus-guards": "workspace:^",
+    "@norns-ui/focus-scope": "workspace:^",
+    "@norns-ui/hooks": "workspace:^",
+    "@norns-ui/norn": "workspace:^",
+    "@norns-ui/portal": "workspace:^",
+    "@norns-ui/presence": "workspace:^",
+    "@norns-ui/shared": "workspace:^",
+    "@norns-ui/slot": "workspace:^",
+    "aria-hidden": "^1.2.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-remove-scroll": "^2.6.0"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dialog/tsconfig.json
+++ b/packages/dialog/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/focus-guards/esbuild.config.js
+++ b/packages/focus-guards/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/focus-guards/eslint.config.js
+++ b/packages/focus-guards/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/focus-guards/lib/FocusGuards.tsx
+++ b/packages/focus-guards/lib/FocusGuards.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {useEffect} from "react";
+
+/** Number of components which have requested interest to have focus guards */
+let count = 0;
+
+const createFocusGuard = () => {
+  const element = document.createElement("span");
+  element.setAttribute("data-norns-focus-guard", "");
+  element.tabIndex = 0;
+  element.style.outline = "none";
+  element.style.opacity = "0";
+  element.style.position = "fixed";
+  element.style.pointerEvents = "none";
+  return element;
+};
+
+/**
+ * Injects a pair of focus guards at the edges of the whole DOM tree
+ * to ensure `focusin` & `focusout` events can be caught consistently.
+ */
+const useFocusGuards = () => {
+  useEffect(() => {
+    const edgeGuards = document.querySelectorAll("[data-norns-focus-guard]");
+    document.body.insertAdjacentElement(
+      "afterbegin",
+      edgeGuards[0] ?? createFocusGuard(),
+    );
+    document.body.insertAdjacentElement(
+      "beforeend",
+      edgeGuards[1] ?? createFocusGuard(),
+    );
+    count++;
+
+    return () => {
+      if (count === 1) {
+        document
+          .querySelectorAll("[data-norns-focus-guard]")
+          .forEach((node) => node.remove());
+      }
+      count--;
+    };
+  }, []);
+};
+
+const FocusGuards = (props: any) => {
+  useFocusGuards();
+  return props.children;
+};
+
+export {FocusGuards, useFocusGuards};

--- a/packages/focus-guards/lib/index.ts
+++ b/packages/focus-guards/lib/index.ts
@@ -1,0 +1,1 @@
+export {FocusGuards, useFocusGuards} from "./FocusGuards";

--- a/packages/focus-guards/package.json
+++ b/packages/focus-guards/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@norns-ui/focus-guards",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/focus-guards/tsconfig.json
+++ b/packages/focus-guards/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/focus-scope/esbuild.config.js
+++ b/packages/focus-scope/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/focus-scope/eslint.config.js
+++ b/packages/focus-scope/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/focus-scope/lib/FocusScope.tsx
+++ b/packages/focus-scope/lib/FocusScope.tsx
@@ -1,0 +1,275 @@
+/* eslint-disable react/no-this-in-sfc */
+"use client";
+
+import {useCallbackRef, useComposedRefs} from "@norns-ui/hooks";
+import {Norn} from "@norns-ui/norn";
+import {
+  focus,
+  focusFirst,
+  getTabbableCandidates,
+  getTabbableEdges,
+} from "@norns-ui/shared";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {focusScopesStack, removeLinks} from "./FocusScopeStack";
+
+const AUTOFOCUS_ON_MOUNT = "focusScope.autoFocusOnMount";
+const AUTOFOCUS_ON_UNMOUNT = "focusScope.autoFocusOnUnmount";
+const EVENT_OPTIONS = {bubbles: false, cancelable: true};
+
+const FOCUS_SCOPE_NAME = "FocusScope";
+
+type FocusScopeElement = ElementRef<typeof Norn.div>;
+type NornDivProps = ComponentPropsWithoutRef<typeof Norn.div>;
+interface FocusScopeProps extends NornDivProps {
+  /**
+   * When `true`, tabbing from last item will focus first tabbable
+   * and shift+tab from first item will focus last tababble.
+   * @defaultValue false
+   */
+  loop?: boolean;
+
+  /**
+   * When `true`, focus cannot escape the focus scope via keyboard,
+   * pointer, or a programmatic focus.
+   * @defaultValue false
+   */
+  trapped?: boolean;
+
+  /**
+   * Event handler called when auto-focusing on mount.
+   * Can be prevented.
+   */
+  onMountAutoFocus?: (event: Event) => void;
+
+  /**
+   * Event handler called when auto-focusing on unmount.
+   * Can be prevented.
+   */
+  onUnmountAutoFocus?: (event: Event) => void;
+}
+
+const FocusScope = forwardRef<FocusScopeElement, FocusScopeProps>(
+  (
+    {
+      loop = false,
+      trapped = false,
+      onMountAutoFocus: onMountAutoFocusProp,
+      onUnmountAutoFocus: onUnmountAutoFocusProp,
+      ...scopeProps
+    },
+    forwardedRef,
+  ) => {
+    const [container, setContainer] = useState<HTMLElement | null>(null);
+    const onMountAutoFocus = useCallbackRef(onMountAutoFocusProp);
+    const onUnmountAutoFocus = useCallbackRef(onUnmountAutoFocusProp);
+    const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+    const composedRefs = useComposedRefs(forwardedRef, (node) =>
+      setContainer(node),
+    );
+
+    const focusScope = useRef({
+      paused: false,
+      pause() {
+        this.paused = true;
+      },
+      resume() {
+        this.paused = false;
+      },
+    }).current;
+
+    // Takes care of trapping focus if focus is moved outside programmatically for example
+    useEffect(() => {
+      if (trapped) {
+        function handleFocusIn(event: FocusEvent) {
+          if (focusScope.paused || !container) {
+            return;
+          }
+          const target = event.target as HTMLElement | null;
+          if (container.contains(target)) {
+            lastFocusedElementRef.current = target;
+          } else {
+            focus(lastFocusedElementRef.current, {select: true});
+          }
+        }
+
+        function handleFocusOut(event: FocusEvent) {
+          if (focusScope.paused || !container) {
+            return;
+          }
+          const relatedTarget = event.relatedTarget as HTMLElement | null;
+
+          // A `focusout` event with a `null` `relatedTarget` will happen in at least two cases:
+          //
+          // 1. When the user switches app/tabs/windows/the browser itself loses focus.
+          // 2. In Google Chrome, when the focused element is removed from the DOM.
+          //
+          // We let the browser do its thing here because:
+          //
+          // 1. The browser already keeps a memory of what's focused for when the page gets refocused.
+          // 2. In Google Chrome, if we try to focus the deleted focused element (as per below), it
+          //    throws the CPU to 100%, so we avoid doing anything for this reason here too.
+          if (relatedTarget === null) {
+            return;
+          }
+
+          // If the focus has moved to an actual legitimate element (`relatedTarget !== null`)
+          // that is outside the container, we move focus to the last valid focused element inside.
+          if (!container.contains(relatedTarget)) {
+            focus(lastFocusedElementRef.current, {select: true});
+          }
+        }
+
+        // When the focused element gets removed from the DOM, browsers move focus
+        // back to the document.body. In this case, we move focus to the container
+        // to keep focus trapped correctly.
+        function handleMutations(mutations: MutationRecord[]) {
+          const focusedElement = document.activeElement as HTMLElement | null;
+          if (focusedElement !== document.body) {
+            return;
+          }
+          for (const mutation of mutations) {
+            if (mutation.removedNodes.length > 0) {
+              focus(container);
+            }
+          }
+        }
+
+        document.addEventListener("focusin", handleFocusIn);
+        document.addEventListener("focusout", handleFocusOut);
+        const mutationObserver = new MutationObserver(handleMutations);
+        if (container) {
+          mutationObserver.observe(container, {childList: true, subtree: true});
+        }
+
+        return () => {
+          document.removeEventListener("focusin", handleFocusIn);
+          document.removeEventListener("focusout", handleFocusOut);
+          mutationObserver.disconnect();
+        };
+      }
+    }, [trapped, container, focusScope.paused]);
+
+    useEffect(() => {
+      if (container) {
+        focusScopesStack.add(focusScope);
+        const previouslyFocusedElement =
+          document.activeElement as HTMLElement | null;
+        const hasFocusedCandidate = container.contains(
+          previouslyFocusedElement,
+        );
+
+        if (!hasFocusedCandidate) {
+          const mountEvent = new CustomEvent(AUTOFOCUS_ON_MOUNT, EVENT_OPTIONS);
+          container.addEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
+          container.dispatchEvent(mountEvent);
+          if (!mountEvent.defaultPrevented) {
+            focusFirst(removeLinks(getTabbableCandidates(container)), {
+              select: true,
+            });
+            if (document.activeElement === previouslyFocusedElement) {
+              focus(container);
+            }
+          }
+        }
+
+        return () => {
+          container.removeEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
+
+          // We hit a react bug (fixed in v17) with focusing in unmount.
+          // We need to delay the focus a little to get around it for now.
+          // See: https://github.com/facebook/react/issues/17894
+          setTimeout(() => {
+            const unmountEvent = new CustomEvent(
+              AUTOFOCUS_ON_UNMOUNT,
+              EVENT_OPTIONS,
+            );
+            container.addEventListener(
+              AUTOFOCUS_ON_UNMOUNT,
+              onUnmountAutoFocus,
+            );
+            container.dispatchEvent(unmountEvent);
+            if (!unmountEvent.defaultPrevented) {
+              focus(previouslyFocusedElement ?? document.body, {select: true});
+            }
+            // we need to remove the listener after we `dispatchEvent`
+            container.removeEventListener(
+              AUTOFOCUS_ON_UNMOUNT,
+              onUnmountAutoFocus,
+            );
+
+            focusScopesStack.remove(focusScope);
+          }, 0);
+        };
+      }
+    }, [container, onMountAutoFocus, onUnmountAutoFocus, focusScope]);
+
+    // Takes care of looping focus (when tabbing whilst at the edges)
+    const handleKeyDown = useCallback(
+      (event: KeyboardEvent) => {
+        if (!loop && !trapped) {
+          return;
+        }
+        if (focusScope.paused) {
+          return;
+        }
+
+        const isTabKey =
+          event.key === "Tab" &&
+          !event.altKey &&
+          !event.ctrlKey &&
+          !event.metaKey;
+        const focusedElement = document.activeElement as HTMLElement | null;
+
+        if (isTabKey && focusedElement) {
+          const container = event.currentTarget as HTMLElement;
+          const [first, last] = getTabbableEdges(container);
+          const hasTabbableElementsInside = first && last;
+
+          // we can only wrap focus if we have tabbable edges
+          if (!hasTabbableElementsInside) {
+            if (focusedElement === container) {
+              event.preventDefault();
+            }
+          } else {
+            if (!event.shiftKey && focusedElement === last) {
+              event.preventDefault();
+              if (loop) {
+                focus(first, {select: true});
+              }
+            } else if (event.shiftKey && focusedElement === first) {
+              event.preventDefault();
+              if (loop) {
+                focus(last, {select: true});
+              }
+            }
+          }
+        }
+      },
+      [loop, trapped, focusScope.paused],
+    );
+
+    return (
+      <Norn.div
+        tabIndex={-1}
+        {...scopeProps}
+        ref={composedRefs}
+        onKeyDown={handleKeyDown}
+      />
+    );
+  },
+);
+
+FocusScope.displayName = FOCUS_SCOPE_NAME;
+
+export {FocusScope};
+export type {FocusScopeProps};

--- a/packages/focus-scope/lib/FocusScopeStack.ts
+++ b/packages/focus-scope/lib/FocusScopeStack.ts
@@ -1,0 +1,41 @@
+const arrayRemove = <T>(array: T[], item: T) => {
+  const updatedArray = [...array];
+  const index = updatedArray.indexOf(item);
+  if (index !== -1) {
+    updatedArray.splice(index, 1);
+  }
+  return updatedArray;
+};
+
+const removeLinks = (items: HTMLElement[]) => {
+  return items.filter((item) => item.tagName !== "A");
+};
+
+const createFocusScopesStack = () => {
+  /** A stack of focus scopes, with the active one at the top */
+  let stack: FocusScopeAPI[] = [];
+
+  return {
+    add(focusScope: FocusScopeAPI) {
+      // pause the currently active focus scope (at the top of the stack)
+      const activeFocusScope = stack[0];
+      if (focusScope !== activeFocusScope) {
+        activeFocusScope?.pause();
+      }
+      // remove in case it already exists (because we'll re-add it at the top of the stack)
+      stack = arrayRemove(stack, focusScope);
+      stack.unshift(focusScope);
+    },
+
+    remove(focusScope: FocusScopeAPI) {
+      stack = arrayRemove(stack, focusScope);
+      stack[0]?.resume();
+    },
+  };
+};
+
+type FocusScopeAPI = {paused: boolean; pause(): void; resume(): void};
+const focusScopesStack = createFocusScopesStack();
+
+export {arrayRemove, focusScopesStack, removeLinks};
+export type {FocusScopeAPI};

--- a/packages/focus-scope/lib/index.ts
+++ b/packages/focus-scope/lib/index.ts
@@ -1,0 +1,2 @@
+export type {FocusScopeProps} from "./FocusScope";
+export {FocusScope} from "./FocusScope";

--- a/packages/focus-scope/package.json
+++ b/packages/focus-scope/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@norns-ui/focus-scope",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "@norns-ui/hooks": "workspace:^",
+    "@norns-ui/norn": "workspace:^",
+    "@norns-ui/shared": "workspace:^",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/focus-scope/tsconfig.json
+++ b/packages/focus-scope/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/portal/esbuild.config.js
+++ b/packages/portal/esbuild.config.js
@@ -1,0 +1,46 @@
+import * as esbuild from "esbuild";
+import * as tsup from "tsup";
+
+const build = async () => {
+  const file = "./lib/index.ts";
+  const dist = "./dist";
+
+  const esbuildConfig = {
+    entryPoints: [file],
+    external: ["@norns-ui/*"],
+    packages: "external",
+    bundle: true,
+    format: "esm",
+    target: "es2022",
+    outdir: dist,
+  };
+
+  await esbuild.build(esbuildConfig);
+  console.log(`Built ./dist/index.js`);
+
+  await esbuild.build({
+    ...esbuildConfig,
+    format: "cjs",
+    outExtension: {".js": ".cjs"},
+  });
+  console.log(`Built ./dist/index.cjs`);
+
+  // tsup is used to emit d.ts files only (esbuild can't do that).
+  //
+  // Notes:
+  // 1. Emitting d.ts files is super slow for whatever reason.
+  // 2. It could have fully replaced esbuild (as it uses that internally),
+  //    but at the moment its esbuild version is somewhat outdated.
+  //    It’s also harder to configure and esbuild docs are more thorough.
+  await tsup.build({
+    entry: [file],
+    format: "esm",
+    dts: {only: true},
+    outDir: dist,
+    silent: true,
+    external: [/@norns-ui\/.+/],
+  });
+  console.log(`Built ./dist/index.d.ts`);
+};
+
+build();

--- a/packages/portal/eslint.config.js
+++ b/packages/portal/eslint.config.js
@@ -1,0 +1,3 @@
+import norns from "@norns-ui/eslint-config-norns";
+
+export default norns();

--- a/packages/portal/lib/Portal.tsx
+++ b/packages/portal/lib/Portal.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {useLayoutEffect} from "@norns-ui/hooks";
+import {Norn} from "@norns-ui/norn";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  useState,
+} from "react";
+import {createPortal} from "react-dom";
+
+const PORTAL_NAME = "Portal";
+
+type PortalElement = ElementRef<typeof Norn.div>;
+type NornDivProps = ComponentPropsWithoutRef<typeof Norn.div>;
+interface PortalProps extends NornDivProps {
+  /**
+   * An optional container where the portaled content should be appended.
+   */
+  container?: Element | DocumentFragment | null;
+}
+
+const Portal = forwardRef<PortalElement, PortalProps>(
+  ({container: containerProp, ...portalProps}, forwardedRef) => {
+    const [mounted, setMounted] = useState(false);
+    useLayoutEffect(() => setMounted(true), []);
+    const container = containerProp || (mounted && globalThis?.document?.body);
+    return container
+      ? createPortal(
+          <Norn.div {...portalProps} ref={forwardedRef} />,
+          container,
+        )
+      : null;
+  },
+);
+
+Portal.displayName = PORTAL_NAME;
+
+export {Portal};
+export type {PortalProps};

--- a/packages/portal/lib/index.ts
+++ b/packages/portal/lib/index.ts
@@ -1,0 +1,2 @@
+export type {PortalProps} from "./Portal";
+export {Portal} from "./Portal";

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@norns-ui/portal",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Dmitriy Chukhno <me@dmitr1sdae.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "node esbuild.config.js",
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix",
+    "pretty": "prettier --check $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "pretty:fix": "prettier --write $(find . -type d \\( -name 'node_modules' -o -name 'dist' \\) -prune -o \\( -type f -name '*.js' -o -name '*.ts' -o -name '*.tsx' \\) -print)",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "dependencies": {
+    "@norns-ui/hooks": "workspace:^",
+    "@norns-ui/norn": "workspace:^",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@norns-ui/eslint-config-norns": "workspace:^",
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.23.0",
+    "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/portal/tsconfig.json
+++ b/packages/portal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["lib/*"]
+    }
+  },
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/shared/lib/tab/findVisible.ts
+++ b/packages/shared/lib/tab/findVisible.ts
@@ -1,0 +1,31 @@
+const isHidden = (node: HTMLElement, {upTo}: {upTo?: HTMLElement}) => {
+  if (getComputedStyle(node).visibility === "hidden") {
+    return true;
+  }
+  while (node) {
+    // we stop at `upTo` (excluding it)
+    if (upTo !== undefined && node === upTo) {
+      return false;
+    }
+    if (getComputedStyle(node).display === "none") {
+      return true;
+    }
+    node = node.parentElement as HTMLElement;
+  }
+  return false;
+};
+
+/**
+ * Returns the first visible element in a list.
+ * NOTE: Only checks visibility up to the `container`.
+ */
+const findVisible = (elements: HTMLElement[], container: HTMLElement) => {
+  for (const element of elements) {
+    // we stop checking if it's hidden at the `container` level (excluding)
+    if (!isHidden(element, {upTo: container})) {
+      return element;
+    }
+  }
+};
+
+export {findVisible};

--- a/packages/shared/lib/tab/focus.ts
+++ b/packages/shared/lib/tab/focus.ts
@@ -1,0 +1,26 @@
+type FocusableTarget = HTMLElement | {focus(): void};
+
+const isSelectableInput = (
+  element: any,
+): element is FocusableTarget & {select: () => void} => {
+  return element instanceof HTMLInputElement && "select" in element;
+};
+
+const focus = (element?: FocusableTarget | null, {select = false} = {}) => {
+  // only focus if that element is focusable
+  if (element && element.focus) {
+    const previouslyFocusedElement = document.activeElement;
+    // NOTE: we prevent scrolling on focus, to minimize jarring transitions for users
+    element.focus({preventScroll: true});
+    // only select if its not the same element, it supports selection and we need to select
+    if (
+      element !== previouslyFocusedElement &&
+      isSelectableInput(element) &&
+      select
+    ) {
+      element.select();
+    }
+  }
+};
+
+export {focus};

--- a/packages/shared/lib/tab/focusFirst.ts
+++ b/packages/shared/lib/tab/focusFirst.ts
@@ -1,13 +1,20 @@
-const focusFirst = (candidates: HTMLElement[]) => {
+import {focus} from "./focus";
+
+const focusFirst = (candidates: HTMLElement[], {select = false} = {}) => {
   const previouslyFocusedElement = document.activeElement;
-  return candidates.some((candidate) => {
-    // if focus is already where we want to go, we don't want to keep going through the candidates
-    if (candidate === previouslyFocusedElement) {
-      return true;
+
+  for (const candidate of candidates) {
+    // Attempt to focus the candidate
+    focus(candidate, {select});
+
+    // If focus has successfully moved to the candidate, exit the loop
+    if (
+      document.activeElement !== previouslyFocusedElement &&
+      document.activeElement === candidate
+    ) {
+      return false; // Successfully focused a candidate
     }
-    candidate.focus();
-    return document.activeElement !== previouslyFocusedElement;
-  });
+  }
 };
 
 export {focusFirst};

--- a/packages/shared/lib/tab/getTabbableEdges.ts
+++ b/packages/shared/lib/tab/getTabbableEdges.ts
@@ -1,0 +1,14 @@
+import {findVisible} from "./findVisible";
+import {getTabbableCandidates} from "./getTabbableCandidates";
+
+/**
+ * Returns the first and last tabbable elements inside a container.
+ */
+const getTabbableEdges = (container: HTMLElement) => {
+  const candidates = getTabbableCandidates(container);
+  const first = findVisible(candidates, container);
+  const last = findVisible(candidates.reverse(), container);
+  return [first, last] as const;
+};
+
+export {getTabbableEdges};

--- a/packages/shared/lib/tab/index.ts
+++ b/packages/shared/lib/tab/index.ts
@@ -1,3 +1,5 @@
+export * from "./focus";
 export * from "./focusFirst";
 export * from "./getTabbableCandidates";
+export * from "./getTabbableEdges";
 export * from "./removeFromTabOrder";

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@norns-ui/dialog@workspace:packages/dialog":
+  version: 0.0.0-use.local
+  resolution: "@norns-ui/dialog@workspace:packages/dialog"
+  dependencies:
+    "@norns-ui/dismissable-layer": "workspace:^"
+    "@norns-ui/eslint-config-norns": "workspace:^"
+    "@norns-ui/focus-guards": "workspace:^"
+    "@norns-ui/hooks": "workspace:^"
+    "@norns-ui/norn": "workspace:^"
+    "@norns-ui/portal": "workspace:^"
+    "@norns-ui/presence": "workspace:^"
+    "@norns-ui/shared": "workspace:^"
+    "@norns-ui/slot": "workspace:^"
+    "@types/node": "npm:^20.14.9"
+    "@types/react": "npm:^18.3.3"
+    "@types/react-dom": "npm:^18.3.0"
+    aria-hidden: "npm:^1.2.4"
+    esbuild: "npm:^0.23.0"
+    eslint: "npm:^9.11.1"
+    prettier: "npm:^3.3.3"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    react-remove-scroll: "npm:^2.6.0"
+    tsup: "npm:^8.2.4"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
 "@norns-ui/dismissable-layer@workspace:^, @norns-ui/dismissable-layer@workspace:packages/dismissable-layer":
   version: 0.0.0-use.local
   resolution: "@norns-ui/dismissable-layer@workspace:packages/dismissable-layer"
@@ -939,7 +967,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@norns-ui/eslint-config-norns@workspace:packages/eslint-config-norns":
+"@norns-ui/eslint-config-norns@workspace:^, @norns-ui/eslint-config-norns@workspace:packages/eslint-config-norns":
   version: 0.0.0-use.local
   resolution: "@norns-ui/eslint-config-norns@workspace:packages/eslint-config-norns"
   dependencies:
@@ -969,6 +997,42 @@ __metadata:
     tsup: "npm:^8.3.0"
     typescript: "npm:^5.6.2"
     typescript-eslint: "npm:^8.7.0"
+  languageName: unknown
+  linkType: soft
+
+"@norns-ui/focus-guards@workspace:^, @norns-ui/focus-guards@workspace:packages/focus-guards":
+  version: 0.0.0-use.local
+  resolution: "@norns-ui/focus-guards@workspace:packages/focus-guards"
+  dependencies:
+    "@norns-ui/eslint-config-norns": "workspace:^"
+    "@types/node": "npm:^20.14.9"
+    "@types/react": "npm:^18.3.3"
+    esbuild: "npm:^0.23.0"
+    eslint: "npm:^9.11.1"
+    prettier: "npm:^3.3.3"
+    react: "npm:^18.3.1"
+    tsup: "npm:^8.2.4"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@norns-ui/focus-scope@workspace:packages/focus-scope":
+  version: 0.0.0-use.local
+  resolution: "@norns-ui/focus-scope@workspace:packages/focus-scope"
+  dependencies:
+    "@norns-ui/eslint-config-norns": "workspace:^"
+    "@norns-ui/hooks": "workspace:^"
+    "@norns-ui/norn": "workspace:^"
+    "@norns-ui/shared": "workspace:^"
+    "@types/node": "npm:^20.14.9"
+    "@types/react": "npm:^18.3.3"
+    "@types/react-dom": "npm:^18.3.0"
+    esbuild: "npm:^0.23.0"
+    eslint: "npm:^9.11.1"
+    prettier: "npm:^3.3.3"
+    react: "npm:^18.3.1"
+    tsup: "npm:^8.2.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1034,6 +1098,26 @@ __metadata:
   dependencies:
     "@norns-ui/eslint-config-norns": "workspace:packages/eslint-config-norns"
     "@norns-ui/slot": "workspace:^"
+    "@types/node": "npm:^20.14.9"
+    "@types/react": "npm:^18.3.3"
+    "@types/react-dom": "npm:^18.3.0"
+    esbuild: "npm:^0.23.0"
+    eslint: "npm:^9.11.1"
+    prettier: "npm:^3.3.3"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    tsup: "npm:^8.2.4"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@norns-ui/portal@workspace:^, @norns-ui/portal@workspace:packages/portal":
+  version: 0.0.0-use.local
+  resolution: "@norns-ui/portal@workspace:packages/portal"
+  dependencies:
+    "@norns-ui/eslint-config-norns": "workspace:^"
+    "@norns-ui/hooks": "workspace:^"
+    "@norns-ui/norn": "workspace:^"
     "@types/node": "npm:^20.14.9"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
@@ -2270,6 +2354,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-hidden@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "aria-hidden@npm:1.2.4"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/8abcab2e1432efc4db415e97cb3959649ddf52c8fc815d7384f43f3d3abf56f1c12852575d00df9a8927f421d7e0712652dd5f8db244ea57634344e29ecfc74a
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:~5.1.3":
   version: 5.1.3
   resolution: "aria-query@npm:5.1.3"
@@ -3387,6 +3480,13 @@ __metadata:
   version: 5.0.0
   resolution: "detect-indent@npm:5.0.0"
   checksum: 10c0/58d985dd5b4d5e5aad6fe7d8ecc74538fa92c807c894794b8505569e45651bf01a38755b65d9d3d17e512239a26d3131837cbef43cf4226968d5abf175bbcc9d
+  languageName: node
+  linkType: hard
+
+"detect-node-es@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "detect-node-es@npm:1.1.0"
+  checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
   languageName: node
   linkType: hard
 
@@ -4649,6 +4749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-nonce@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "get-nonce@npm:1.0.1"
+  checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
+  languageName: node
+  linkType: hard
+
 "get-pkg-repo@npm:^4.2.1":
   version: 4.2.1
   resolution: "get-pkg-repo@npm:4.2.1"
@@ -5230,6 +5337,15 @@ __metadata:
     hasown: "npm:^2.0.0"
     side-channel: "npm:^1.0.4"
   checksum: 10c0/f8b294a4e6ea3855fc59551bbf35f2b832cf01fd5e6e2a97f5c201a071cc09b49048f856e484b67a6c721da5e55736c5b6ddafaf19e2dbeb4a3ff1821680de6c
+  languageName: node
+  linkType: hard
+
+"invariant@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: "npm:^1.0.0"
+  checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
   languageName: node
   linkType: hard
 
@@ -6277,7 +6393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -7807,6 +7923,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-remove-scroll-bar@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "react-remove-scroll-bar@npm:2.3.6"
+  dependencies:
+    react-style-singleton: "npm:^2.2.1"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/4e32ee04bf655a8bd3b4aacf6ffc596ae9eb1b9ba27eef83f7002632ee75371f61516ae62250634a9eae4b2c8fc6f6982d9b182de260f6c11841841e6e2e7515
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "react-remove-scroll@npm:2.6.0"
+  dependencies:
+    react-remove-scroll-bar: "npm:^2.3.6"
+    react-style-singleton: "npm:^2.2.1"
+    tslib: "npm:^2.1.0"
+    use-callback-ref: "npm:^1.3.0"
+    use-sidecar: "npm:^1.1.2"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/c5881c537477d986e8d25d2588a9b6f7fe1254e05946fb4f4b55baeead502b0e1875fc3c42bb6f82736772cd96a50266e41d84e3c4cd25e9525bdfe2d838e96d
+  languageName: node
+  linkType: hard
+
+"react-style-singleton@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "react-style-singleton@npm:2.2.1"
+  dependencies:
+    get-nonce: "npm:^1.0.0"
+    invariant: "npm:^2.2.4"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/6d66f3bdb65e1ec79089f80314da97c9a005087a04ee034255a5de129a4c0d9fd0bf99fa7bf642781ac2dc745ca687aae3de082bd8afdd0d117bc953241e15ad
+  languageName: node
+  linkType: hard
+
 "react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -8977,17 +9145,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.0, tslib@npm:^2.6.2":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0":
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
   checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.6.2":
-  version: 2.7.0
-  resolution: "tslib@npm:2.7.0"
-  checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6
   languageName: node
   linkType: hard
 
@@ -9369,6 +9537,37 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"use-callback-ref@npm:^1.3.0":
+  version: 1.3.2
+  resolution: "use-callback-ref@npm:1.3.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d232c37160fe3970c99255da19b5fb5299fb5926a5d6141d928a87feb47732c323d29be2f8137d3b1e5499c70d284cd1d9cfad703cc58179db8be24d7dd8f1f2
+  languageName: node
+  linkType: hard
+
+"use-sidecar@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "use-sidecar@npm:1.1.2"
+  dependencies:
+    detect-node-es: "npm:^1.1.0"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/89f0018fd9aee1fc17c85ac18c4bf8944d460d453d0d0e04ddbc8eaddf3fa591e9c74a1f8a438a1bff368a7a2417fab380bdb3df899d2194c4375b0982736de0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Added `DialogClose` component for closing the dialog.
- Implemented `DialogContent`, supporting both modal and non-modal behavior, with focus management and accessibility warnings.
- Created `DialogDescription` for describing dialog content.
- Introduced `DialogOverlay` for overlay management with `RemoveScroll` integration.
- Added `DialogPortal` to handle dialog content portal and mount control.
- Implemented `DialogTitle` for accessible dialog headings.
- Created `DialogTrigger` component for opening dialogs.